### PR TITLE
Clean GitHub actions log

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - clean_github_actions_log
 
 name: Tests
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - clean_github_actions_log
 
 name: Tests
 

--- a/code/src/main.cpp
+++ b/code/src/main.cpp
@@ -44,7 +44,6 @@ int main() {
     std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
     for (int j = image_height - 1; j >= 0; --j) {
-        std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
         for (int i = 0; i < image_width; ++i) {
             auto u = double(i) / (image_width - 1);
             auto v = double(j) / (image_height - 1);

--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -30,7 +30,7 @@ echo "Running app..."
 docker exec \
     -w '/home' \
     build_test \
-    sh -c './build/raytracer > /dev/null 2>&1 ; echo "::set-output name=quick_run_result::$?"'
+    sh -c './build/raytracer > /dev/null ; echo "::set-output name=quick_run_result::$?"'
 
 echo "Building unit tests..."
 

--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -30,7 +30,7 @@ echo "Running app..."
 docker exec \
     -w '/home' \
     build_test \
-    sh -c './build/raytracer; echo "::set-output name=quick_run_result::$?"'
+    sh -c './build/raytracer 1> /dev/null; echo "::set-output name=quick_run_result::$?"'
 
 echo "Building unit tests..."
 

--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -30,7 +30,7 @@ echo "Running app..."
 docker exec \
     -w '/home' \
     build_test \
-    sh -c './build/raytracer 1> /dev/null; echo "::set-output name=quick_run_result::$?"'
+    sh -c './build/raytracer > /dev/null 2>&1 ; echo "::set-output name=quick_run_result::$?"'
 
 echo "Building unit tests..."
 


### PR DESCRIPTION
This is a work in progress, but my proposed solution to avoid cluttering the Actions console is to redirect all output from `raytracer` to `/dev/null`.

Currently, the applications sends the pixel values it generates to standard output, as well as some useful debugging information to standard error. I would like to keep the standard error info in case something goes wrong but we also output stuff like `std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;` to standard error. In my opinion, these `Scanlines remaining: ` messages already clutter the console.

What do you think @sergio-nnz? Should we just redirect all output to `/dev/null`? Or should we modify the application and maybe remove all but the most critical messages that go to `std::cerr`? (In that case, we would only need to redirect things that go to standard output like this: `./raytracer 1> /dev/null`).