### PR TITLE
fix_toolchain_version_check: Add missing colon to README.md file.

### DIFF
--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -16,4 +16,4 @@ There are two options to run the container: interactive and detached mode. To ru
 
 ## About
 
-Version 0.2.2
+Version: 0.2.2


### PR DESCRIPTION
Without this colon, the `build_container.sh` script cannot find and replace the Version number in `toolchain/README.md`.