### PR TITLE
sphere_random_loop: Improve the RandomInUnitSphere method 

### DIFF
--- a/code/include/vector3.h
+++ b/code/include/vector3.h
@@ -75,7 +75,8 @@ inline Vector3 Cross(const Vector3& u, const Vector3& v)
 
 inline Vector3 UnitVector(const Vector3& v)
 {
-	return v / v.Length();
+    auto length = v.Length();
+    return length == 0 ? Vector3(0.0, 0.0, 0.0) : v / length;
 }
 
 Vector3 RandomInUnitSphere();

--- a/code/lib/vector3.cpp
+++ b/code/lib/vector3.cpp
@@ -62,9 +62,11 @@ double Vector3::LengthSquared() const {
 }
 
 Vector3 RandomInUnitSphere() {
-	auto p = Vector3::Random(-1, 1);
-	while (p.LengthSquared() >= 1) {
-		p = Vector3::Random(-1, 1);
-	}
-	return p;
+    auto uniform_value = RandomDouble(0, 1);
+    auto radius = std::cbrt(uniform_value);
+    auto random_vector = Vector3::Random(-1, 1);
+
+    random_vector /= random_vector.Length();
+
+	return radius*random_vector;
 }

--- a/code/lib/vector3.cpp
+++ b/code/lib/vector3.cpp
@@ -62,11 +62,14 @@ double Vector3::LengthSquared() const {
 }
 
 Vector3 RandomInUnitSphere() {
+    // Normalized random vector
+    auto random_vector = UnitVector(Vector3::Random(-1, 1));
+
+    /* Spread uniform value across volume so that, over time random points
+     * don't cluster around the center of the sphere. */
     auto uniform_value = RandomDouble(0, 1);
     auto radius = std::cbrt(uniform_value);
-    auto random_vector = Vector3::Random(-1, 1);
 
-    random_vector /= random_vector.Length();
-
-	return radius*random_vector;
+    // Scale vector inside a unit sphere
+	return radius * random_vector;
 }

--- a/code/tests/unittests/test_vector3.cpp
+++ b/code/tests/unittests/test_vector3.cpp
@@ -200,9 +200,18 @@ TEST(Vector3RandomTest, RandomWhenMinLessThanMaxThrowsNoError) {
 }
 
 TEST(Vector3RandomTest, RandomInUnitSphereNoParametersVectorIsInsideUnitSphere) {
-    auto result = RandomInUnitSphere();
+    bool isInsideSphere = true;
+    int numberOfTests = 1000;
 
-    ASSERT_LT(result.LengthSquared(), 1);
+    for (int i = 0; i < numberOfTests; i++) {
+        auto result = RandomInUnitSphere();
+        if (result.LengthSquared() >= 1) {
+            isInsideSphere = false;
+            break;
+        }
+    }
+
+    ASSERT_TRUE(isInsideSphere);
 }
 
 TEST_P(Vector3RandomTest, RandomWhenPassingMinMaxParametersReturnsVectorWithinRange) {

--- a/code/tests/unittests/test_vector3.cpp
+++ b/code/tests/unittests/test_vector3.cpp
@@ -124,6 +124,14 @@ TEST_F(Vector3Test, UnitVectorWhenPassingAVector3ReturnsItsUnitVector) {
     ASSERT_THAT(actual_vector.e, ElementsAreArray(expected_vector.e));
 }
 
+TEST_F(Vector3Test, UnitVectorWhenVectorLengthIs0ReturnsAZeroVector) {
+    Vector3 expected_vector(0.0, 0.0, 0.0);
+
+    Vector3 actual_vector = UnitVector(Vector3(0.0, 0.0, 0.0));
+
+    ASSERT_THAT(actual_vector.e, ElementsAreArray(expected_vector.e));
+}
+
 TEST_F(Vector3Test, LengthWhenNoParamsReturnsSquareRootOfTheVectorsLengthSquared) {
     double expectedValue = std::sqrt(3.0);
 


### PR DESCRIPTION
Improve the RandomInUnitSphere method by using normally distributed random numbers to get a random point in a sphere.