### PR TITLE
actions_enable_color: Force gtest to use colors.

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -44,7 +44,7 @@ echo "Running unit tests..."
 docker exec \
     -w '/home' \
     build_test \
-    sh -c './build/bin/raytracer_tests; echo "::set-output name=run_unit_tests_result::$?"'
+    sh -c './build/bin/raytracer_tests --gtest_color=yes; echo "::set-output name=run_unit_tests_result::$?"'
 
 echo "Stopping container..."
 


### PR DESCRIPTION
Use the `gtest_color` command line flag to make sure that colors are
enabled. This is necessary to enable colors for tests running on GitHub
Actions.